### PR TITLE
Add module syntax support using es6-module-transpiler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var through = require('through');
 var es6arrowfn = require('es6-arrow-function');
 var es6class = require('es6-class');
 var es6defaultParams = require('es6-default-params');
+var es6module = require('es6-module-transpiler');
 var es6restParams = require('es6-rest-params');
 var es6spread = require('es6-spread');
 var es6templates = require('es6-templates');
@@ -24,6 +25,7 @@ var recast = require('recast');
  *   generator - Compile generator functions into ES5. Default: on.
  *   includeRuntime - Include any runtime needed for compilers that require a
  *                    runtime. Default: variable.
+ *   modules - Compile ES6 module syntax into ES6. Default: off.
  *
  * @param {string} source
  * @param {object} options
@@ -54,6 +56,11 @@ function compile(source, options) {
  *   generator - Compile generator functions into ES5.
  *   rest - Compile rest params into ES5.
  *   templates - Compile template strings into ES5.
+ *   modules - Compile ES6 module syntax into ES6.
+ *    opts:
+ *      type: "cjs"|"amd"|"yui" for module output
+ *      name: name for the module, default is name of the file
+ *      options: pass in imports/global/etc. from options arg in Compiler
  *
  * @param {object} ast
  * @param {object} options
@@ -72,6 +79,34 @@ function transform(ast, options) {
 
   if (options.defaultParams !== false) {
     ast = es6defaultParams.transform(ast);
+  }
+
+  if (!!options.modules) {
+    options.modules = options.modules || {};
+
+    var Compiler = es6module.Compiler,
+        source = recast.print(ast, {}),
+        opts = options.modules.opts || {},
+        compiler = new Compiler(source.code, opts.name, opts.options),
+        generatedModules;
+
+    switch (opts.type) {
+      case 'amd':
+        generatedModules = compiler.toAMD();
+        break;
+      case 'cjs':
+        generatedModules = compiler.toCJS();
+        break;
+      case 'yui':
+        generatedModules = compiler.toYUI();
+        break;
+      default:
+        generatedModules = compiler.toAMD();
+    }
+
+    ast = recast.parse(generatedModules, {
+      esprima: esprima
+    });
   }
 
   if (options.generator !== false) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ast-types": "^0.3.24",
     "es6-default-params": "^0.0.1",
     "es6-spread": "^0.0.4",
-    "es6-rest-params": "^0.1.0"
+    "es6-rest-params": "^0.1.0",
+    "es6-module-transpiler": "^0.4.0"
   }
 }


### PR DESCRIPTION
Took a swing at getting module syntax in, this is totally a proof-of-concept/WIP. Wanted to see if it was possible initially, ended up working fine and would appreciate feedback on this.

Not a fan of translating to source to transpile module syntax and throwing back up the AST after, any thoughts on a better approach?

``` js
var compile = require('./lib/index').compile,
    source = "var foo = (a, b) => {}, bar = 'bar'; f(...x); export { foo, bar };";

console.log(compile(source, {
  modules: true
}).code);
```

produced

``` js
define(
  ["exports"],
  function(__exports__) {
    "use strict";
    var foo = function(a, b) {}, bar = 'bar'; f.apply(null, Array.prototype.slice.call(x)); __exports__.foo = foo;
    __exports__.bar = bar;
  });
```
