### PR TITLE
[ES6] Computed properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ npm install [--save-dev] esnext
 * [default params][features-default-rest-spread] (via [es6-default-params][es6-default-params])
 * [spread][features-default-rest-spread] (via [es6-spread][es6-spread])
 * [comprehensions][features-comprehensions] (via [es6-comprehensions][es6-comprehensions])
+* [computed properties][features-computed-properties] (via [es6-computed-properties][es6-computed-properties])
 
 ### TODO
 
@@ -147,6 +148,7 @@ the [es6-module-transpiler][es6-module-transpiler], [es6-class][es6-class],
 [es6-rest-params]: https://github.com/thomasboyt/es6-rest-params
 [es6-spread]: https://github.com/square/es6-spread
 [es6-templates]: https://github.com/square/es6-templates
+[es6-computed-properties]: https://github.com/DmitrySoshnikov/es6-computed-properties
 [es6features]: https://github.com/lukehoban/es6features
 [esprima]: https://github.com/ariya/esprima
 [features-arrows]: https://github.com/lukehoban/es6features#arrows
@@ -158,6 +160,7 @@ the [es6-module-transpiler][es6-module-transpiler], [es6-class][es6-class],
 [features-let-const]: https://github.com/lukehoban/es6features#let--const
 [features-modules]: https://github.com/lukehoban/es6features#modules
 [features-template-strings]: https://github.com/lukehoban/es6features#template-strings
+[features-computed-properties]:https://github.com/lukehoban/es6features#enhanced-object-literals
 [grunt-esnext]: https://github.com/shinnn/grunt-esnext
 [gulp-esnext]: https://github.com/sindresorhus/gulp-esnext
 [recast]: https://github.com/benjamn/recast

--- a/bin/esnext
+++ b/bin/esnext
@@ -61,6 +61,10 @@ for (var i = 0, length = args.length; i < length; i++) {
       options.templates = (arg === '--templates');
       break;
 
+    case '--computed-props': case '--no-computed-props':
+      options.computedProps = (arg === '--computed-props');
+      break;
+
     case '--source-maps': case '--no-source-maps':
       sourceMaps = (arg === '--source-maps');
       break;
@@ -164,6 +168,7 @@ function usage(puts) {
   puts('  --generator             Transpile generator functions.');
   puts('  --rest                  Transpile rest params.');
   puts('  --templates             Transpile template strings.');
+  puts('  --computed-props        Transpile Object Literal computed properties.');
   puts();
   puts(bold('Output Options'));
   puts();

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var es6spread = require('es6-spread');
 var es6templates = require('es6-templates');
 var regenerator = require('regenerator');
 var es6comprehensions = require('es6-comprehensions');
+var es6computedProperties = require('es6-computed-properties');
 
 var esprima = require('esprima');
 var recast = require('recast');
@@ -91,6 +92,10 @@ function transform(ast, options) {
 
   if (options.arrayComprehensions !== false) {
     ast = es6comprehensions.transform(ast);
+  }
+
+  if (options.computedProps !== false) {
+    ast = es6computedProperties.transform(ast);
   }
 
   return ast;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "es6-spread": "^0.0.5",
     "es6-rest-params": "^0.1.1",
     "es6-comprehensions": "^0.2.2",
+    "es6-computed-properties": "^0.0.1",
     "mkdirp": "^0.5.0"
   }
 }

--- a/test/examples/computed-props.js
+++ b/test/examples/computed-props.js
@@ -1,0 +1,10 @@
+/* jshint esnext:true */
+
+var x = 'a';
+var y = 'b';
+
+var foo = {
+  [x + y]: 10
+};
+
+assert.equal(foo.ab, 10);


### PR DESCRIPTION
ES6 Computed properties of Object Literals.

This diff just adds as a dependency the: https://github.com/DmitrySoshnikov/es6-computed-properties

``` js
var x = 'a';
var y = 'b';

var foo = {
    [x + y]: 10
};

console.log(foo); // {ab: 10}
```

Note: main esprima version of the `esnext` project should be updated to address the computed properties feature that recently was merged.
