### PR TITLE
fix deprecation warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function compile(source, options) {
   ast = transform(ast, options);
   return recast.print(ast, {
     sourceMapName: options.sourceMapName
-  });
+  }).code;
 }
 
 /**


### PR DESCRIPTION
Recast's API changed a bit recently - if you use the output of `recast.print()` directly you get the following warning:

> Deprecation warning: recast.print now returns an object with a .code property. You appear to be treating the object as a string, which might still work but is strongly discouraged.

This PR fixes that. Thanks!
