### PR TITLE
Add support for ES6 Unicode regular expressions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var es6restParams = require('es6-rest-params');
 var es6spread = require('es6-spread');
 var es6templates = require('es6-templates');
 var regenerator = require('regenerator');
+var regexpu = require('regexpu');
 
 var esprima = require('esprima-fb');
 var recast = require('recast');
@@ -87,6 +88,10 @@ function transform(ast, options) {
 
   if (options.generator !== false) {
     ast = regenerator.transform(ast);
+  }
+
+  if (options.regexpu !== false) {
+    ast = regexpu.transform(ast);
   }
 
   if (options.spread !== false) {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "es6-rest-params": "^0.1.1",
     "es6-spread": "^0.0.5",
     "es6-templates": "^0.0.3",
-    "esprima-fb": "^6001.1001.0-dev-harmony-fb",
+    "esprima-fb": "^7001.1.0-dev-harmony-fb",
     "mkdirp": "^0.5.0",
     "recast": "^0.5.17",
     "regenerator": "^0.6.5",
+    "regexpu": "^0.3.0",
     "through": "^2.3.4"
   }
 }

--- a/test/examples/all-together.js
+++ b/test/examples/all-together.js
@@ -89,3 +89,7 @@ assert.equal(countersHash["2"], y);
 assert.equal(countersHash["3"], z);
 assert.equal(countersHash["three"], z);
 assert.equal(countersHash.toString(), "[CounterHash]");
+
+var string = 'foo\uD834\uDF06bar';
+var match = string.match(/foo(.)bar/u);
+assert.equal(match[1], '\uD834\uDF06');

--- a/test/examples/unicode-regular-expressions.js
+++ b/test/examples/unicode-regular-expressions.js
@@ -1,0 +1,5 @@
+/* jshint esnext:true */
+
+var string = 'foo\uD834\uDF06bar';
+var match = string.match(/foo(.)bar/u);
+assert.equal(match[1], '\uD834\uDF06');


### PR DESCRIPTION
The regular expression transpilation is handled by regexpu (https://mths.be/regexpu).

This depends on the Esprima patch in https://github.com/esnext/esprima/pull/1 or https://github.com/facebook/esprima/pull/42.
