### PR TITLE
test(ci): test on node v12 instead of node v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,10 @@ aliases:
       - *save_cache_step
       - run:
           name: tests
-          command: 'yarn test'
+          command: 'yarn jest --ci'
 
 version: 2
 jobs:
-  node-v6-latest:
-    docker:
-      - image: circleci/node:6
-    <<: *unit_test
   node-v8-latest:
     docker:
       - image: circleci/node:8
@@ -40,12 +36,16 @@ jobs:
     docker:
       - image: circleci/node:11
     <<: *unit_test
+  node-v12-latest:
+    docker:
+      - image: circleci/node:12
+    <<: *unit_test
 
 workflows:
   version: 2
   test:
     jobs:
-      - node-v6-latest
       - node-v8-latest
       - node-v10-latest
       - node-v11-latest
+      - node-v12-latest

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Brian Donovan",
   "license": "MIT",


### PR DESCRIPTION

BREAKING CHANGE: We no longer care about node v6 since it is EOL.