### PR TITLE
fix(codemod-functions-arrow): transform function arguments to `new` expressions

### DIFF
--- a/packages/resugar-codemod-functions-arrow/src/index.ts
+++ b/packages/resugar-codemod-functions-arrow/src/index.ts
@@ -32,7 +32,7 @@ export default function({ types: t }: typeof Babel): Babel.PluginObj {
         }
 
         // `new` can't be called on arrow functions.
-        if (t.isNewExpression(parent)) {
+        if (t.isNewExpression(parent) && parent.callee === node) {
           return;
         }
 

--- a/packages/resugar-codemod-functions-arrow/test/__fixtures__/processes-functions-as-argument-to-new-expression.input.js
+++ b/packages/resugar-codemod-functions-arrow/test/__fixtures__/processes-functions-as-argument-to-new-expression.input.js
@@ -1,0 +1,3 @@
+new Promise(function() {
+  return 42;
+});

--- a/packages/resugar-codemod-functions-arrow/test/__fixtures__/processes-functions-as-argument-to-new-expression.output.js
+++ b/packages/resugar-codemod-functions-arrow/test/__fixtures__/processes-functions-as-argument-to-new-expression.output.js
@@ -1,0 +1,1 @@
+new Promise(() => 42);


### PR DESCRIPTION

Refs https://github.com/decaffeinate/decaffeinate/issues/1385.