### PR TITLE
fix: sync scope by registering new declarations

### DIFF
--- a/packages/resugar-codemod-modules-commonjs/package.json
+++ b/packages/resugar-codemod-modules-commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resugar/codemod-modules-commonjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Convert CommonJS `require` and `module.exports` to ES module syntax.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/resugar-codemod-modules-commonjs/src/index.ts
+++ b/packages/resugar-codemod-modules-commonjs/src/index.ts
@@ -176,10 +176,12 @@ function rewriteStatementsAsDefaultExport(programPath: NodePath<t.Program>) {
     exportPaths[exportPaths.length - 1]
   );
 
-  firstStatement.insertBefore(
-    t.variableDeclaration('var', [
-      t.variableDeclarator(exportsIdentifier, t.objectExpression([]))
-    ])
+  lastStatement.scope.registerDeclaration(
+    firstStatement.insertBefore(
+      t.variableDeclaration('var', [
+        t.variableDeclarator(exportsIdentifier, t.objectExpression([]))
+      ])
+    )[0]
   );
 
   for (const exportPath of exportPaths) {

--- a/packages/resugar-codemod-modules-commonjs/test/test.ts
+++ b/packages/resugar-codemod-modules-commonjs/test/test.ts
@@ -1,5 +1,44 @@
 import { defineTestSuites } from '@resugar/test-runner';
 import { join } from 'path';
 import modulesCommonjs from '../src';
+import { transform } from '@codemod/core';
+import { NodePath, Scope } from '@babel/traverse';
+import * as t from '@babel/types';
 
 defineTestSuites(join(__dirname, '__fixtures__'), [modulesCommonjs]);
+
+describe('scope consistency', () => {
+  test('default export binding is added to the scope', () => {
+    transform('exports.a = 1;', {
+      plugins: [
+        [modulesCommonjs, { forceDefaultExport: true }],
+        {
+          visitor: {
+            Program(path: NodePath<t.Program>): void {
+              expect(scopeBindingNames(path.scope)).toContain('_defaultExport');
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  test('named export binding is added to the scope', () => {
+    transform('exports.a = 1;', {
+      plugins: [
+        modulesCommonjs,
+        {
+          visitor: {
+            Program(path: NodePath<t.Program>): void {
+              expect(scopeBindingNames(path.scope)).toContain('_a');
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  function scopeBindingNames(scope: Scope): ReadonlyArray<string> {
+    return Object.keys(scope.getAllBindings());
+  }
+});

--- a/packages/resugar-helper-comments/package.json
+++ b/packages/resugar-helper-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resugar/helper-comments",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Utilities for manipulating comments in an AST.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION

`@babel/traverse` has built-in `NodePath` manipulations like `insertBefore` and `replaceWith`, but these operations do not automatically discover new declarations in the inserted AST nodes. This change manually notifies the scope of new paths to find declarations in.

This prevents situations where a new variable declaration is added but not included in the scope, and a subsequent plugin goes looking for the scope binding associated with the new variable declaration and fails because the scope is out of sync.