### PR TITLE
fix: allow export declarations to be idiomatic

### DIFF
--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/adds-a-name-to-exported-anonymous-functions.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/adds-a-name-to-exported-anonymous-functions.output.js
@@ -1,5 +1,3 @@
-function _add(a, b) {
+export function add(a, b) {
   return a + b;
 }
-
-export { _add as add };

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/converts-complex-forced-default-export.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/converts-complex-forced-default-export.output.js
@@ -1,17 +1,17 @@
 // config={"forceDefaultExport": true}
 console.log('Start of file');
-var _defaultExport = {};
-_defaultExport = a;
+var defaultExport = {};
+defaultExport = a;
 if (b) {
-  _defaultExport.d = e;
+  defaultExport.d = e;
 }
-for (let f in _defaultExport) {
-  _defaultExport[f]++;
+for (let f in defaultExport) {
+  defaultExport[f]++;
 }
-_defaultExport[g] = {
+defaultExport[g] = {
   h() {
     console.log(this);
   }
 };
-export default _defaultExport;
+export default defaultExport;
 console.log('End of file');

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/does-not-shadow-globals.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/does-not-shadow-globals.output.js
@@ -6,17 +6,17 @@ function _clearTimeout(timeout) {
 export { _clearTimeout as clearTimeout };
 
 // use the existing name that won't shadow a local or global
-let _setTimeout2 = function _setTimeout(callback, timeout) {
+let __setTimeout = function _setTimeout(callback, timeout) {
   setTimeout(callback, timeout);
 };
 
-export { _setTimeout2 as setTimeout };
+export { __setTimeout as setTimeout };
 
 // give function a local binding that won't shadow a local or global
 function _clearInterval() {}
 
-let _clearInterval2 = function _clearInterval(interval) {
+let __clearInterval = function _clearInterval(interval) {
   clearInterval(interval);
 };
 
-export { _clearInterval2 as clearInterval };
+export { __clearInterval as clearInterval };

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/export-named-global.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/export-named-global.output.js
@@ -1,2 +1,1 @@
-let _jQuery = $;
-export { _jQuery as jQuery };
+export let jQuery = $;

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/exports-non-function-values-as-export-let.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/exports-non-function-values-as-export-let.output.js
@@ -1,2 +1,1 @@
-let _PI = 3.14;
-export { _PI as PI };
+export let PI = 3.14;

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/ignores-a-missing-semi-colon-when-changing-an-export-from-an-assignment-to-export-function.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/ignores-a-missing-semi-colon-when-changing-an-export-from-an-assignment-to-export-function.output.js
@@ -1,2 +1,1 @@
-function _foo() {}
-export { _foo as foo };
+export function foo() {}

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/parenthesized-named-export.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/parenthesized-named-export.output.js
@@ -1,2 +1,1 @@
-let _a = b;
-export { _a as a };
+export let a = b;

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/removes-the-semi-colon-when-changing-an-export-from-an-assignment-to-export-function.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/removes-the-semi-colon-when-changing-an-export-from-an-assignment-to-export-function.output.js
@@ -1,2 +1,1 @@
-function _foo() {}
-export { _foo as foo };
+export function foo() {}

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/rewrites-exports-within-unwrapped-iife.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/rewrites-exports-within-unwrapped-iife.output.js
@@ -1,2 +1,1 @@
-let _foo = 1;
-export { _foo as foo };
+export let foo = 1;

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/toplevel-this-function-export.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/toplevel-this-function-export.output.js
@@ -1,2 +1,1 @@
-function _log(message) { console.log(message); }
-export { _log as log };
+export function log(message) { console.log(message); }

--- a/packages/resugar-codemod-modules-commonjs/test/__fixtures__/works-with-object-destructuring-for-named-exports.output.js
+++ b/packages/resugar-codemod-modules-commonjs/test/__fixtures__/works-with-object-destructuring-for-named-exports.output.js
@@ -1,2 +1,1 @@
-let _find = Array.prototype.find;
-export { _find as find };
+export let find = Array.prototype.find;

--- a/packages/resugar-codemod-modules-commonjs/test/test.ts
+++ b/packages/resugar-codemod-modules-commonjs/test/test.ts
@@ -15,7 +15,7 @@ describe('scope consistency', () => {
         {
           visitor: {
             Program(path: NodePath<t.Program>): void {
-              expect(scopeBindingNames(path.scope)).toContain('_defaultExport');
+              expect(scopeBindingNames(path.scope)).toContain('defaultExport');
             }
           }
         }
@@ -30,7 +30,7 @@ describe('scope consistency', () => {
         {
           visitor: {
             Program(path: NodePath<t.Program>): void {
-              expect(scopeBindingNames(path.scope)).toContain('_a');
+              expect(scopeBindingNames(path.scope)).toContain('a');
             }
           }
         }


### PR DESCRIPTION

`@babel/traverse` has `Scope#generateUid` which generates a unique ID based on a given name. What I'd like for that method to do is to always use that name if possible, but to generate names based on it if not. That is not how it works, unfortunately, so I wrote my own based on it.

The upshot is that what was previously this:

```js
let _PI = 3.14;
export { _PI as PI };
```

is now this:

```js
export let PI = 3.14;
```

Much nicer.